### PR TITLE
Add rudimentary support for marge@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "peerDependencies": {
     "@wdio/cli": "^5.8.4",
-    "mochawesome-report-generator": "^3.1.5"
+    "mochawesome-report-generator": "^4.0.0"
   },
   "jest": {
     "testPathIgnorePatterns": [

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,7 @@ class WdioMochawesomeReporter extends WDIOReporter {
         // mochawesome requires this root suite for HTML report generation to work properly
         this.results = {
             stats: new Stats(runner.start),
-            suites: new Suite(true, {'title': ''}),
-            copyrightYear: new Date().getFullYear()
+            results: new Array(new Suite(true, { 'title': '' })),
         }
     }
 
@@ -53,7 +52,7 @@ class WdioMochawesomeReporter extends WDIOReporter {
 
     onSuiteEnd (suite) {
         this.currSuite.duration = suite.duration
-        this.results.suites.addSuite(this.currSuite)
+        this.results.results[0].addSuite(this.currSuite)
     }
 
     onRunnerEnd (runner) {

--- a/src/stats.js
+++ b/src/stats.js
@@ -15,8 +15,6 @@ module.exports = class {
         this.hasOther = false
         this.skipped = 0
         this.hasSkipped = false
-        this.passPercentClass = 'success'
-        this.pendingPercentClass = 'danger'
     }
 
     incrementSuites () {
@@ -33,9 +31,8 @@ module.exports = class {
         } else if (result.pending) {
             this.pending += 1
             this.skipped += 1
-            this.hasSkipped = true
         }
-
+        this.hasSkipped = this.skipped > 0;
         this.passPercent = this.tests === 0 ? 0 : Math.round((this.passes / this.tests) * 100)
         this.pendingPercent = this.tests === 0 ? 0 : Math.round((this.pending / this.tests) * 100)
     }

--- a/src/test.js
+++ b/src/test.js
@@ -12,7 +12,6 @@ module.exports = class {
         this.fail = false
         this.pending = false
         this.code = ''
-        this.isRoot = false
         this.uuid = uuid()
         this.parentUUID = suiteUUID
         this.skipped = false

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,9 +14,8 @@ describe('Reporter Tests',()=>{
 
     it('onRunnerStart',()=>{
         expect(reporter.results).toMatchObject({ 
-            copyrightYear: expect.anything(),
             stats: expect.anything(),
-            suites: expect.anything()
+            results: expect.anything()
         })
         expect(reporter.sanitizedCaps).toBe(runner.sanitizedCapabilities)
         expect(reporter.sessionId).toBe(runner.sessionId)
@@ -99,7 +98,7 @@ describe('Reporter Tests',()=>{
 
         expect(reporter.currSuite.duration).toBe(suite.duration)
         expect(reporter.results.stats.suites).toBe(1)
-        expect(reporter.results.suites.suites.length).toBe(1)
+        expect(reporter.results.results[0].suites.length).toBe(1)
     })
 
     it('onRunnerEnd', () =>{


### PR DESCRIPTION
#48 
Not sure how the meta tags work for now.

With `marge@4`, the reporter seems to be missing a `list-style: none` for the suites thus displaying an ugly looking dot before. Maybe it has to do with the formatting of the JSON?
![image](https://user-images.githubusercontent.com/5074186/64916639-79f90400-d757-11e9-9596-86adb8acd0fa.png)

The `onSuiteEnd()` method needs to be verified with more care, accessing a fixed index seems hackish but I tested with only one file


