### PR TITLE
Skip invalid json files when merging

### DIFF
--- a/src/mergeResults.js
+++ b/src/mergeResults.js
@@ -16,7 +16,12 @@ function getDataFromFiles (dir, filePattern) {
     const data = []
 
     fileNames.forEach(fileName => {
-        data.push(JSON.parse(fs.readFileSync(`${dir}/${fileName}`)))
+        // Ignore file if it's malformed JSON
+        try {
+            data.push(JSON.parse(fs.readFileSync(`${dir}/${fileName}`)))
+        } catch (err) {
+            console.warn(`Ignoring file ${fileName}, err: ${err.message}`)
+        }
     })
 
     return data


### PR DESCRIPTION
**Problem**
It's possible that a reporter creates empty json result file. This might happen when there are problems with Webdriver connection. And if there is an empty json file, merging will fail, making it impossible to generate a final result file.

Example:
Let's say I am running test with 10 browsers. One browser fails to start and there is empty json file created. Now just because of one of the test I am unable to see test results of the test run. I heavily rely on HTML report generated by using merged result file. Now image the pain when I run hundreds of tests.

**Solution**
Skip the files which have invalid JSON by adding try/catch block for `JSON.parse`.
I have also added console log for skipped files but I am not sure if that needs to stay.